### PR TITLE
Fix FastAPI imports and conversation DB thread safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/
 # Logs
 *.log
 *.sqlite3
+*.db

--- a/backend/conversations.py
+++ b/backend/conversations.py
@@ -19,7 +19,7 @@ class ConversationManager:
     def __init__(self, db_path: str = "conversations.sqlite3") -> None:
         # Connect to the SQLite database. If the file does not exist, it will be created.
         self.db_path = db_path
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._create_tables()
 
     def _create_tables(self) -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,8 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from pydantic import BaseModel
-from typing import List, Optional
-from autonomy import AutonomyManager
-from memory import MemoryManager
-from conversations import ConversationManager
+from .autonomy import AutonomyManager
+from .memory import MemoryManager
+from .conversations import ConversationManager
 
 # Instantiate memory and autonomy managers
 memory_manager = MemoryManager()
@@ -25,18 +24,14 @@ async def read_root():
 
 @app.post("/query")
 async def handle_query(request: QueryRequest):
-    """
-        Handle user queries by forwarding the request to the primary language model,
-    asking clarifying questions via the autonomy manager, and returning the final response.
-    """
-        session_id = "default"
+    """Handle a user query and return Dexter's response."""
+    session_id = "default"
     conversation_manager.add_message(session_id, "user", request.query)
-    # conversation_manager.add_message(session_id, "assistant", response)
-
 
     clarifications = await autonomy_manager.ask_clarifications(request.query)
     response = await autonomy_manager.process_request(request.query)
-        conversation_manager.add_message(session_id, "assistant", response)
 
-return {"response": response, "clarifications": clarifications}
+    conversation_manager.add_message(session_id, "assistant", response)
+
+    return {"response": response, "clarifications": clarifications}
 


### PR DESCRIPTION
## Summary
- use package-relative imports and clean up `/query` endpoint
- allow conversation history SQLite access across threads
- ignore generated `.db` files

## Testing
- `python -m py_compile backend/*.py`
- `python - <<'PY'
from backend.main import app
from fastapi.testclient import TestClient
client = TestClient(app)
print('GET /', client.get('/').status_code, client.get('/').json())
response = client.post('/query', json={'query': 'Hello'})
print('POST /query', response.status_code, response.json())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c02957ed38832a96d6da11ef0bdbeb