### PR TITLE
Add initial backend tests and configuration

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pydantic
 requests
 click
+
+pytest
+httpx

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for imports
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from backend import main
+from backend.memory import MemoryManager
+from backend.autonomy import AutonomyManager
+from backend.conversations import ConversationManager
+
+
+def setup_app(tmp_path):
+    memory = MemoryManager(db_path=str(tmp_path / "memory.db"))
+    autonomy = AutonomyManager(memory=memory)
+    conversations = ConversationManager(db_path=str(tmp_path / "conversations.sqlite3"))
+    main.memory_manager = memory
+    main.autonomy_manager = autonomy
+    main.conversation_manager = conversations
+    return TestClient(main.app)
+
+
+def test_healthcheck():
+    client = TestClient(main.app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Dexter backend is up"}
+
+
+def test_query_endpoint(tmp_path):
+    client = setup_app(tmp_path)
+    resp = client.post("/query", json={"query": "Hello"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["response"] == "Received your request: Hello"
+    assert data["clarifications"] == [
+        "Could you please provide more details about your request?",
+        "What specific format or length do you expect?",
+    ]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,13 @@
+from backend.memory import MemoryManager
+
+
+def test_memory_add_and_query(tmp_path):
+    db_file = tmp_path / "memory.db"
+    mem = MemoryManager(db_path=str(db_file), short_term_limit=3)
+    mem.add_message("user", "hello")
+    mem.add_message("assistant", "hi")
+    context = mem.get_recent_context()
+    assert context[-1]["content"] == "hi"
+    assert len(context) == 2
+    mem.add_knowledge("Dexter", "is", "agent")
+    assert ("is", "agent") in mem.query_knowledge("Dexter")


### PR DESCRIPTION
## Summary
- add pytest configuration and test suite for backend API and memory manager
- include pytest and httpx in backend requirements for local testing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02e711fc8832a82d840a90c45f1e1