### PR TITLE
feat: internal clarifications and collaboration signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This repository is under active development. See `IMPROVEMENT_PLAN.md` for high-
 ### Advanced collaboration
 
 The backend now includes a lightweight ``CollaborationHub`` which broadcasts
-user queries, Dexter's clarifying questions, and responses to any number of
-listeners. This enables real-time cooperation between Dexter and supporting
-teammates or tools. Clarifying questions are generated dynamically to surface
-intent, constraints, and success criteria, giving collaborators the context and
-time they need to craft high-quality solutions.
+user queries, Dexter's clarifying questions, answers, and responses to any
+number of listeners. This enables real-time cooperation between Dexter and
+supporting teammates or tools. Clarifying questions are generated using
+Dexter's own heuristics—no external LLM calls are required. Once the user has
+answered the questions a ``clarifications_complete`` event notifies
+collaborators to begin proposing and voting on solutions.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,4 +6,3 @@ click
 
 pytest
 httpx
-openai

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -1,0 +1,38 @@
+import asyncio
+from backend.autonomy import AutonomyManager
+from backend.collaboration import CollaborationHub
+
+
+def test_ask_clarifications_generates_three_questions_and_broadcasts():
+    hub = CollaborationHub()
+    events = []
+
+    async def listener(event_type, payload):
+        events.append((event_type, payload))
+
+    hub.subscribe(listener)
+    mgr = AutonomyManager(collaboration=hub)
+
+    questions = asyncio.run(mgr.ask_clarifications("build a web app"))
+
+    assert len(questions) == 3
+    types = [e[0] for e in events]
+    assert types[0] == "user_query"
+    assert types.count("clarifying_question") == 3
+
+
+def test_record_clarification_answers_broadcasts_and_signals_complete():
+    hub = CollaborationHub()
+    events = []
+
+    async def listener(event_type, payload):
+        events.append((event_type, payload))
+
+    hub.subscribe(listener)
+    mgr = AutonomyManager(collaboration=hub)
+
+    asyncio.run(mgr.record_clarification_answers(["ans1", "ans2", "ans3"]))
+
+    types = [e[0] for e in events]
+    assert types.count("clarification_answer") == 3
+    assert types[-1] == "clarifications_complete"


### PR DESCRIPTION
## Summary
- replace OpenAI clarifying question generator with deterministic template
- broadcast clarification answers and completion signal to collaborators
- remove OpenAI dependency and document collaboration flow

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0470cc4e4832aba57c3e7eada4935