### PR TITLE
feat: scaffold production React frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,21 @@
 # Dexter Frontend
 
-This directory will contain the React-based frontend for Dexter. The goal is to provide a streamlined and customizable interface where each language model slot can be resized, moved, minimized, or maximized.
+This React application provides the web interface for Dexter. It is built with [Vite](https://vitejs.dev/).
 
-Key planned features:
+## Getting Started
 
-- **Multiple LLM panes**: Each slot (Dexter, Analyst, Engineer, etc.) will have its own chat panel. Panels can be rearranged and resized via a grid layout, making it easy to view conversations side by side.
-- **Clarifying dialogue**: Dexter will ask clarifying questions directly through conversation, rather than using hard‑coded patterns. The UI will display these questions and the user’s answers in real time to all collaborating models.
-- **Persistent state**: Input drafts and chat history will persist across refreshes to prevent losing work while typing.
-- **Speech support**: Optional text‑to‑speech and speech‑to‑text capabilities for hands‑free interaction.
+```bash
+cd frontend
+npm install --no-package-lock
+npm run dev
+```
 
-This is a placeholder file outlining the intended direction for the Dexter frontend. Implementation details will be added as development progresses.
+The UI expects a backend running at `http://localhost:8000` by default. To point to a different backend, set the `VITE_API_BASE_URL` environment variable.
+
+## Production Build
+
+```bash
+npm run build
+```
+
+The compiled assets will be output to the `dist/` directory.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dexter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "axios": "^1.5.0",
     "react-draggable": "^4.4.5",
     "react-resizable": "^3.0.4",
-    "react-grid-layout": "^1.3.4"
+    "react-grid-layout": "^1.3.4",
+    "framer-motion": "^10.18.0",
+    "lucide-react": "^0.428.0"
   },
   "devDependencies": {
     "vite": "^4.0.4",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { motion, Reorder } from "framer-motion";
 import { Home, Database, Settings, Zap, Brain, FileText, Download, Send, Power, Volume2, VolumeX, SlidersHorizontal, Plus, Trash } from "lucide-react";
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";
+
 // --- Default slots (blank labels) ---
 const defaultSlots = [
   {
@@ -9,7 +11,7 @@ const defaultSlots = [
     label: "",
     enabled: true,
     local: true,
-    endpoint: "http://localhost:8000/llm/slot1",
+    endpoint: `${API_BASE_URL}/llm/slot1`,
     model: "",
     apiKey: "",
     temperature: 0.5,
@@ -19,7 +21,7 @@ const defaultSlots = [
   },
 ];
 
-export default function DexterSidebarUI() {
+export default function App() {
   const [active, setActive] = useState("conversations");
   const [autonomous, setAutonomous] = useState(false);
   const [slots, setSlots] = useState(defaultSlots);
@@ -41,28 +43,28 @@ export default function DexterSidebarUI() {
 
   // --- API INTEGRATIONS ---
   useEffect(() => {
-    fetch("/api/skills")
+    fetch(`${API_BASE_URL}/api/skills`)
       .then((res) => res.json())
       .then((data) => setSkills(data || []))
       .catch(() => setSkills([]));
   }, []);
 
   useEffect(() => {
-    fetch("/api/downloads")
+    fetch(`${API_BASE_URL}/api/downloads`)
       .then((res) => res.json())
       .then((data) => setDownloads(data || []))
       .catch(() => setDownloads([]));
   }, []);
 
   useEffect(() => {
-    const logSource = new EventSource("/api/events?slot=logs");
+    const logSource = new EventSource(`${API_BASE_URL}/api/events?slot=logs`);
     logSource.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data);
         setLogs((prev) => [...prev.slice(-200), data]);
       } catch {}
     };
-    const patternSource = new EventSource("/api/events?slot=patterns");
+    const patternSource = new EventSource(`${API_BASE_URL}/api/events?slot=patterns`);
     patternSource.onmessage = (e) => {
       try {
         const data = JSON.parse(e.data);
@@ -89,7 +91,7 @@ export default function DexterSidebarUI() {
         label: "",
         enabled: true,
         local: true,
-        endpoint: `http://localhost:8000/llm/${newId}`,
+        endpoint: `${API_BASE_URL}/llm/${newId}`,
         model: "",
         apiKey: "",
         temperature: 0.5,

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,12 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const API_BASE_URL = process.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
 export default defineConfig({
   plugins: [react()],
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: API_BASE_URL,
         changeOrigin: true
       }
     }


### PR DESCRIPTION
## Summary
- migrate experimental UI into Vite React app
- add environment-based API configuration and proxy
- document frontend setup and install UI dependencies

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0502130f0832ab456656ca5b511b2